### PR TITLE
Remove some of the Load path madness

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,10 @@
+require 'rubygems'
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
 require 'rake'
 require 'spec/rake/spectask'
 

--- a/lib/navvy.rb
+++ b/lib/navvy.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.dirname(__FILE__) + '/navvy/worker')
-require File.expand_path(File.dirname(__FILE__) + '/navvy/logger')
-require File.expand_path(File.dirname(__FILE__) + '/navvy/configuration')
+require 'navvy/worker'
+require 'navvy/logger'
+require 'navvy/configuration'
 
 module Navvy
   class << self

--- a/lib/navvy/job/active_record.rb
+++ b/lib/navvy/job/active_record.rb
@@ -133,4 +133,4 @@ module Navvy
   end
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../job')
+require 'navvy/job'

--- a/lib/navvy/job/data_mapper.rb
+++ b/lib/navvy/job/data_mapper.rb
@@ -151,4 +151,4 @@ module Navvy
   end
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../job')
+require 'navvy/job'

--- a/lib/navvy/job/mongo_mapper.rb
+++ b/lib/navvy/job/mongo_mapper.rb
@@ -147,4 +147,4 @@ module Navvy
   end
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../job')
+require 'navvy/job'

--- a/lib/navvy/job/mongoid.rb
+++ b/lib/navvy/job/mongoid.rb
@@ -136,4 +136,4 @@ module Navvy
   end
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../job')
+require 'navvy/job'

--- a/lib/navvy/job/sequel.rb
+++ b/lib/navvy/job/sequel.rb
@@ -134,4 +134,4 @@ module Navvy
   end
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../job')
+require 'navvy/job'

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 describe Navvy::Configuration do
   after do

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 describe 'Navvy::Job' do
   before do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 describe Navvy::Logger do
   describe '#colorized_info' do

--- a/spec/setup/active_record.rb
+++ b/spec/setup/active_record.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../../lib/navvy/job/active_record')
+require 'navvy/job/active_record'
 
 ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => '/tmp/navvy_test.sqlite')
 

--- a/spec/setup/data_mapper.rb
+++ b/spec/setup/data_mapper.rb
@@ -1,4 +1,5 @@
-require File.expand_path(File.dirname(__FILE__) + '/../../lib/navvy/job/data_mapper')
+require 'navvy/job/data_mapper'
+
 DataMapper.setup(:default, "sqlite3:///tmp/navvy_test.sqlite")
 DataMapper.finalize
 Navvy::Job.auto_migrate!

--- a/spec/setup/mongo_mapper.rb
+++ b/spec/setup/mongo_mapper.rb
@@ -1,2 +1,3 @@
-require File.expand_path(File.dirname(__FILE__) + '/../../lib/navvy/job/mongo_mapper')
+require 'navvy/job/mongo_mapper'
+
 MongoMapper.database = 'navvy_test'

--- a/spec/setup/mongoid.rb
+++ b/spec/setup/mongoid.rb
@@ -6,4 +6,4 @@ Mongoid.configure do |config|
   config.master = Mongo::Connection.new.db(name)
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../../lib/navvy/job/mongoid')
+require 'navvy/job/mongoid'

--- a/spec/setup/sequel.rb
+++ b/spec/setup/sequel.rb
@@ -18,4 +18,4 @@ Sequel::DATABASES[0].create_table!(:jobs) do
   DateTime  :failed_at
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../../lib/navvy/job/sequel')
+require 'navvy/job/sequel'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,18 @@
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'rubygems'
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
 require 'navvy'
 require 'spec'
 require 'timecop'
 require 'spec/autorun'
 
-Spec::Runner.configure do |config|
-end
+
+Spec::Runner.configure { |config| }
+
 
 def job_count
   if defined? Navvy::Job.count

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'spec_helper'
 
 describe Navvy::Worker do
   describe '.fetch_and_run_jobs' do


### PR DESCRIPTION
Hey Jeff,

Here is a small commit which cleans up the way files are required. I have also added bundler/setup to the Rakefile and spec_helper so can you call rake or spec without having to add 'bundle exec' (similar to how mongoid, carrierierwave and similar project do it).

Let me know if you see any issues with the commit.

Thanks,

Josh
