### PR TITLE
Don't retry if Navvy::Job::NoRetryException is raised by the job

### DIFF
--- a/lib/navvy/configuration.rb
+++ b/lib/navvy/configuration.rb
@@ -1,6 +1,6 @@
 module Navvy
   class Configuration
-    attr_accessor :job_limit, :keep_jobs, :logger, :sleep_time, :max_attempts
+    attr_accessor :job_limit, :keep_jobs, :logger, :sleep_time, :max_attempts, :parallel
 
     def initialize
       @job_limit =    100
@@ -8,6 +8,7 @@ module Navvy
       @logger =       Navvy::Logger.new
       @sleep_time =   5
       @max_attempts = 25
+      @parallel =     false
     end
   end
 end

--- a/lib/navvy/job.rb
+++ b/lib/navvy/job.rb
@@ -88,9 +88,9 @@ module Navvy
         Navvy::Job.keep? ? completed(result) : destroy
         result
       rescue NoRetryException => exception
-        failed(exception.message, false)
+        failed(exception.message, nil, false)
       rescue Exception => exception
-        failed(exception.message)
+        failed(exception.message, exception.backtrace)
       end
     end
 

--- a/lib/navvy/job.rb
+++ b/lib/navvy/job.rb
@@ -42,6 +42,22 @@ module Navvy
     end
 
     ##
+    # Whether workers are running in parallel
+    # Currently only implemented in the mongo_mapper adapter using findAndModify
+    # so we can update atomically and return the next job
+    #
+    # If true, only one job is processed at a time (limit is ignored) as findAndModify
+    # only returns one item
+    #
+    # Uses the value in Navvy.configuration (defaults to false)
+    #
+    # @return [Boolean] parallel
+
+    def self.parallel
+      Navvy.configuration.parallel
+    end
+
+    ##
     # Should the job be kept? Will calculate if the keeptime has passed if
     # @keep is a Fixnum. Otherwise, it'll just return the @keep value since
     # it's probably a boolean.

--- a/lib/navvy/job/active_record.rb
+++ b/lib/navvy/job/active_record.rb
@@ -103,15 +103,16 @@ module Navvy
     ##
     # Mark the job as failed. Will set failed_at to the current time and
     # optionally add the exception message if provided. Also, it will retry
-    # the job unless max_attempts has been reached.
+    # the job unless max_attempts has been reached or retryable is false.
     #
     # @param [String] exception the exception message you want to store.
+    # @param [true, false] whether or not to attempt to retry the job
     #
     # @return [true, false] update_attributes the result of the
     # update_attributes call
 
-    def failed(message = nil)
-      self.retry unless times_failed >= self.class.max_attempts
+    def failed(message = nil, retryable = true)
+      self.retry unless !retryable || times_failed >= self.class.max_attempts
       update_attributes(
         :failed_at => Time.now,
         :exception => message

--- a/lib/navvy/job/data_mapper.rb
+++ b/lib/navvy/job/data_mapper.rb
@@ -120,17 +120,17 @@ module Navvy
 
     ##
     # Mark the job as failed. Will set failed_at to the current time and
-    # optionally add the exception message if provided.
     # optionally add the exception message if provided. Also, it will retry
-    # the job unless max_attempts has been reached.
+    # the job unless max_attempts has been reached or retryable is false.
     #
     # @param [String] exception the exception message you want to store.
+    # @param [true, false] whether or not to attempt to retry the job
     #
     # @return [true, false] update_attributes the result of the
     # update_attributes call
 
-    def failed(message = nil)
-      self.retry unless times_failed >= self.class.max_attempts
+    def failed(message = nil, retryable = true)
+      self.retry unless !retryable || times_failed >= self.class.max_attempts
       update(
         :failed_at => Time.now,
         :exception => message

--- a/lib/navvy/job/mongo_mapper.rb
+++ b/lib/navvy/job/mongo_mapper.rb
@@ -74,6 +74,8 @@ module Navvy
             :sort => 'priority desc, created_at asc'
           )
 
+          return [] if result.nil?
+
           # we could return the actual object by setting :new => true
           # but we know exactly what we set so there's no point waiting
           # update the returned document so it's the same as in the db

--- a/lib/navvy/job/mongo_mapper.rb
+++ b/lib/navvy/job/mongo_mapper.rb
@@ -116,15 +116,16 @@ module Navvy
     ##
     # Mark the job as failed. Will set failed_at to the current time and
     # optionally add the exception message if provided. Also, it will retry
-    # the job unless max_attempts has been reached.
+    # the job unless max_attempts has been reached or retryable is false.
     #
     # @param [String] exception the exception message you want to store.
+    # @param [true, false] whether or not to attempt to retry the job
     #
     # @return [true, false] update_attributes the result of the
     # update_attributes call
 
-    def failed(message = nil)
-      self.retry unless times_failed >= self.class.max_attempts
+    def failed(message = nil, retryable = true)
+      self.retry unless !retryable || times_failed >= self.class.max_attempts
       update_attributes(
         :failed_at => Time.now,
         :exception => message

--- a/lib/navvy/job/mongo_mapper.rb
+++ b/lib/navvy/job/mongo_mapper.rb
@@ -10,6 +10,7 @@ module Navvy
     key :priority,      Integer, :default => 0
     key :return,        String
     key :exception,     String
+    key :backtrace,     String
     key :parent_id,     ObjectId
     key :created_at,    Time
     key :run_at,        Time
@@ -153,11 +154,12 @@ module Navvy
     # @return [true, false] update_attributes the result of the
     # update_attributes call
 
-    def failed(message = nil, retryable = true)
+    def failed(message = nil, backtrace = nil, retryable = true)
       self.retry unless !retryable || times_failed >= self.class.max_attempts
       update_attributes(
         :failed_at => Time.now,
-        :exception => message
+        :exception => message,
+        :backtrace => backtrace.try(:join, "\n")
       )
     end
 

--- a/lib/navvy/job/mongo_mapper.rb
+++ b/lib/navvy/job/mongo_mapper.rb
@@ -80,7 +80,7 @@ module Navvy
 
         rescue Mongo::OperationFailure => e
           # raises Mongo::OperationFailure when nothing is found (IE no jobs left)
-          nil
+          []
         end
       else
         all(

--- a/lib/navvy/job/mongoid.rb
+++ b/lib/navvy/job/mongoid.rb
@@ -108,15 +108,16 @@ module Navvy
     ##
     # Mark the job as failed. Will set failed_at to the current time and
     # optionally add the exception message if provided. Also, it will retry
-    # the job unless max_attempts has been reached.
+    # the job unless max_attempts has been reached or retryable is false.
     #
     # @param [String] exception the exception message you want to store.
+    # @param [true, false] whether or not to attempt to retry the job
     #
     # @return [true, false] update_attributes the result of the
     # update_attributes call
 
-    def failed(message = nil)
-      self.retry unless times_failed >= self.class.max_attempts
+    def failed(message = nil, retryable = true)
+      self.retry unless !retryable || times_failed >= self.class.max_attempts
       update_attributes(:failed_at => Time.now, :exception => message)
     end
 

--- a/lib/navvy/job/sequel.rb
+++ b/lib/navvy/job/sequel.rb
@@ -105,15 +105,16 @@ module Navvy
     ##
     # Mark the job as failed. Will set failed_at to the current time and
     # optionally add the exception message if provided. Also, it will retry
-    # the job unless max_attempts has been reached.
+    # the job unless max_attempts has been reached or retryable is false.
     #
     # @param [String] exception the exception message you want to store.
+    # @param [true, false] whether or not to attempt to retry the job
     #
     # @return [true, false] update_attributes the result of the
     # update_attributes call
 
-    def failed(message = nil)
-      self.retry unless times_failed >= self.class.max_attempts
+    def failed(message = nil, retryable = true)
+      self.retry unless !retryable || times_failed >= self.class.max_attempts
       update(
         :failed_at => Time.now,
         :exception => message

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -7,6 +7,7 @@ describe Navvy::Configuration do
       config.keep_jobs =  false
       config.logger =     Navvy::Logger.new('/dev/null')
       config.sleep_time = 5
+      config.parallel =   false
     end
   end
 
@@ -65,4 +66,13 @@ describe Navvy::Configuration do
 
     Navvy::Job.max_attempts.should == 15
   end
+  
+  it "should set parallel to true" do
+    Navvy.configure do |config|
+      config.parallel = true
+    end
+
+    Navvy::Job.parallel.should == true
+  end
+  
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ class Cow
   def self.broken
     raise 'this method is broken'
   end
+
+  def self.broken_no_retry
+    raise Navvy::Job::NoRetryException.new("this method is broken with no retry")
+  end
 end
 
 module Animals


### PR DESCRIPTION
Most of the time if a job fails it's fine to retry later, however some things aren't recoverable and there's no point constantly retrying. For these things I still want to fail the job so that it comes up in our admin interface as failed and I can investigate it, but I don't want it to retry.

To this end, I added an exception (Navvy::Job::NoRetryException) which if raised by the job means that it won't bother queuing it up for a retry.
